### PR TITLE
Use Symfony's provided Route annotation

### DIFF
--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -2,7 +2,7 @@
 
 namespace DieSchittigs\ContaoContentApiBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use DieSchittigs\ContaoContentApiBundle\FrontendApi;


### PR DESCRIPTION
Contao 4.4.24 removes the sensio/frameworks-extra-bundle dependency
which contains the class referenced for Symfony routing by this bundle.
This class has been deprecated in Symfony 5.2 because it became part of
the Symfony core.

Fixes #6

**Not yet tested**