### PR TITLE
Stop using $_SESSION['TL_LANGUAGE'] and add "use Contao\ModuleProxy;"…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Gets the file or directory at `path` and also it's children, limited by `depth`
 
 [Example](examples/file.json)
 
-All routes also take the additional `lang` parameter (e.g. `?lang=de`). If you
+All routes also take the additional `lang` or `_locale` parameter (e.g. `?lang=de` or `?_locale=de`). If you
 need to override the language.
 
 ## Configuration

--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -52,7 +52,11 @@ class ContentApiController extends Controller
         // Override $_SERVER['REQUEST_URI']
         $_SERVER['REQUEST_URI'] = $request->query->get('url', $_SERVER['REQUEST_URI']);
         // Set the language
-        if ($request->query->has('lang')) {
+        if($request->query->has('_locale'))
+        {
+            $this->lang = $request->query->get('_locale');
+        }
+        elseif ($request->query->has('lang')) {
             $this->lang = $request->query->get('lang');
         } elseif (Config::get('addLanguageToUrl') && $request->query->has('url')) {
             $url = $request->query->get('url');
@@ -89,6 +93,7 @@ class ContentApiController extends Controller
             }
             System::loadLanguageFile('default', $this->lang);
         }
+
         // Initialize Contao
         $this->container->get('contao.framework')->initialize();
         $this->apiUser = new ApiUser();

--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -52,11 +52,9 @@ class ContentApiController extends Controller
         // Override $_SERVER['REQUEST_URI']
         $_SERVER['REQUEST_URI'] = $request->query->get('url', $_SERVER['REQUEST_URI']);
         // Set the language
-        if($request->query->has('_locale'))
-        {
+        if ($request->query->has('_locale')) {
             $this->lang = $request->query->get('_locale');
-        }
-        elseif ($request->query->has('lang')) {
+        } elseif ($request->query->has('lang')) {
             $this->lang = $request->query->get('lang');
         } elseif (Config::get('addLanguageToUrl') && $request->query->has('url')) {
             $url = $request->query->get('url');
@@ -76,10 +74,8 @@ class ContentApiController extends Controller
             }
         }
         if ($this->lang) {
-            if(defined('VERSION'))
-            {
-                if (version_compare(VERSION, '4.0', '<='))
-                {
+            if (defined('VERSION')) {
+                if (version_compare(VERSION, '4.0', '<=')) {
                     /**
                      * Using the globals `$GLOBALS['TL_LANGUAGE']` and `$_SESSION['TL_LANGUAGE']`
                      * has been deprecated in Contao 4.0
@@ -92,6 +88,9 @@ class ContentApiController extends Controller
                 }
             }
             System::loadLanguageFile('default', $this->lang);
+        } else {
+            // Use Contao fallback language
+            System::loadLanguageFile('default', 'undefined');
         }
 
         // Initialize Contao
@@ -110,11 +109,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/sitemap", name="content_api_sitemap")
      *
-     * @param Request $request Current request
      */
     public function sitemapAction(Request $request)
     {
@@ -125,11 +124,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/sitemap/flat", name="content_api_sitemap_flat")
      *
-     * @param Request $request Current request
      */
     public function sitemapFlatAction(Request $request)
     {
@@ -139,11 +138,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/page", name="content_api_page")
      *
-     * @param Request $request Current request
      */
     public function pageAction(Request $request)
     {
@@ -156,11 +155,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/user", name="content_api_user")
      *
-     * @param Request $request Current request
      */
     public function userAction(Request $request)
     {
@@ -170,28 +169,30 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/text", name="content_api_text")
      *
-     * @param Request $request Current request
      */
     public function textAction(Request $request)
     {
         $request = $this->init($request);
 
-        return new ContentApiResponse(TextHelper::get(
-            explode(',', $request->query->get('file', 'default')),
-            $this->lang
-        ), 200, $this->headers);
+        return new ContentApiResponse(
+            TextHelper::get(
+                explode(',', $request->query->get('file', 'default')),
+                $this->lang
+            ), 200, $this->headers
+        );
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/file", name="content_api_file")
      *
-     * @param Request $request Current request
      */
     public function fileAction(Request $request)
     {
@@ -203,11 +204,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/module", name="content_api_module")
      *
-     * @param Request $request Current request
      */
     public function moduleAction(Request $request)
     {
@@ -217,11 +218,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/urls", name="content_api_urls")
      *
-     * @param Request $request Current request
      */
     public function urlsAction(Request $request)
     {
@@ -232,12 +233,12 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param string $reader Reader (e.g. newsreader)
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/{reader}", name="content_api_reader")
      *
-     * @param string  $reader  Reader (e.g. newsreader)
-     * @param Request $request Current request
      */
     public function readerAction(string $reader, Request $request)
     {
@@ -260,11 +261,11 @@ class ContentApiController extends Controller
     }
 
     /**
+     * @param Request $request Current request
      * @return Response
      *
      * @Route("/", name="content_api_auto")
      *
-     * @param Request $request Current request
      */
     public function indexAction(Request $request)
     {

--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -72,8 +72,21 @@ class ContentApiController extends Controller
             }
         }
         if ($this->lang) {
-            $GLOBALS['TL_LANGUAGE'] = $this->lang;
-            $_SESSION['TL_LANGUAGE'] = $this->lang;
+            if(defined('VERSION'))
+            {
+                if (version_compare(VERSION, '4.0', '<='))
+                {
+                    /**
+                     * Using the globals `$GLOBALS['TL_LANGUAGE']` and `$_SESSION['TL_LANGUAGE']`
+                     * has been deprecated in Contao 4.0
+                     * and will no longer work in Contao 5.0. Use the
+                     * locale from the request object instead:
+                     * $locale = System::getContainer()->get('request_stack')->getCurrentRequest()->getLocale();
+                     */
+                    $_SESSION['TL_LANGUAGE'] = $this->lang;
+                    $GLOBALS['TL_LANGUAGE'] = $this->lang;
+                }
+            }
             System::loadLanguageFile('default', $this->lang);
         }
         // Initialize Contao

--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -27,8 +27,20 @@ use DieSchittigs\ContaoContentApiBundle\ApiUser;
  */
 class ContentApiController extends Controller
 {
+    /**
+     * @var ApiUser
+     */
     private $apiUser;
+
+    /**
+     * @var null
+     */
     private $lang = null;
+
+    /**
+     * @var string
+     */
+    private $header;
 
     /**
      * Called at the begin of every request.
@@ -51,6 +63,7 @@ class ContentApiController extends Controller
                 $request = $callback[0]::{$callback[1]}($request);
             }
         }
+        
         // Override $_SERVER['REQUEST_URI']
         $_SERVER['REQUEST_URI'] = $request->query->get('url', $_SERVER['REQUEST_URI']);
 

--- a/src/Controller/ContentApiController.php
+++ b/src/Controller/ContentApiController.php
@@ -43,7 +43,9 @@ class ContentApiController extends Controller
         if (!$this->getParameter('content_api_enabled')) {
             die('Content API is disabled');
         }
+
         $this->headers = $this->getParameter('content_api_headers');
+
         if (isset($GLOBALS['TL_HOOKS']['apiBeforeInit']) && is_array($GLOBALS['TL_HOOKS']['apiBeforeInit'])) {
             foreach ($GLOBALS['TL_HOOKS']['apiBeforeInit'] as $callback) {
                 $request = $callback[0]::{$callback[1]}($request);
@@ -51,6 +53,7 @@ class ContentApiController extends Controller
         }
         // Override $_SERVER['REQUEST_URI']
         $_SERVER['REQUEST_URI'] = $request->query->get('url', $_SERVER['REQUEST_URI']);
+
         // Set the language
         if ($request->query->has('_locale')) {
             $this->lang = $request->query->get('_locale');

--- a/src/DependencyInjection/ContentApiExtension.php
+++ b/src/DependencyInjection/ContentApiExtension.php
@@ -15,6 +15,7 @@ class ContentApiExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
         $loader->load('parameters.yml');
     }
 }

--- a/src/Resources/contao/ApiUser.php
+++ b/src/Resources/contao/ApiUser.php
@@ -3,6 +3,7 @@
 namespace DieSchittigs\ContaoContentApiBundle;
 
 use Contao\Frontend;
+use Contao\FrontendUser;
 use Contao\MemberModel;
 
 /**
@@ -11,9 +12,15 @@ use Contao\MemberModel;
  */
 class ApiUser extends Frontend implements ContaoJsonSerializable
 {
+    /**
+     * @var FrontendUser
+     */
+    private $User;
+
     public function __construct()
     {
         $this->import('FrontendUser', 'User');
+
         parent::__construct();
         define('FE_USER_LOGGED_IN', $this->getLoginStatus('FE_USER_AUTH'));
     }

--- a/src/Resources/contao/Module.php
+++ b/src/Resources/contao/Module.php
@@ -4,6 +4,7 @@ namespace DieSchittigs\ContaoContentApiBundle;
 
 use Contao\ModuleModel;
 use Contao\Module;
+use Contao\ModuleProxy;
 
 /**
  * ApiModule augments ModuleModel for the API.

--- a/src/Resources/contao/Module.php
+++ b/src/Resources/contao/Module.php
@@ -12,32 +12,36 @@ use Contao\ModuleProxy;
 class ApiModule extends AugmentedContaoModel
 {
     /**
-     * constructor.
-     *
-     * @param int $id id of the ModuleModel
+     * @var ModuleModel|null
+     */
+    public $model;
+
+    /**
+     * ApiModule constructor.
+     * @param $id
      */
     public function __construct($id)
     {
+
         $this->model = ModuleModel::findByPk($id);
-        $moduleClass = Module::findClass($this->type);
+
+        $moduleClass = Module::findClass($this->model->type);
         try {
             $strColumn = null;
             // Add compatibility to new front end module fragments
-            if(defined('VERSION'))
-            {
-                if (version_compare(VERSION, '4.5', '>='))
-                {
-                    if ($moduleClass === ModuleProxy::class)
-                    {
+            if (defined('VERSION')) {
+                if (version_compare(VERSION, '4.5', '>=')) {
+                    if ($moduleClass === ModuleProxy::class) {
                         $strColumn = 'main';
                     }
                 }
             }
-            $module = new $moduleClass($this->model, $strColumn);            
+            $module = new $moduleClass($this->model, $strColumn);
             $this->compiledHTML = @$module->generate() ?? null;
         } catch (\Exception $e) {
             $this->compiledHTML = null;
         }
+
         if (isset($GLOBALS['TL_HOOKS']['apiModuleGenerated']) && is_array($GLOBALS['TL_HOOKS']['apiModuleGenerated'])) {
             foreach ($GLOBALS['TL_HOOKS']['apiModuleGenerated'] as $callback) {
                 $callback[0]::{$callback[1]}($this, $moduleClass);

--- a/src/Resources/contao/Sitemap.php
+++ b/src/Resources/contao/Sitemap.php
@@ -38,7 +38,6 @@ class Sitemap implements \IteratorAggregate, \ArrayAccess, \Countable, ContaoJso
         foreach ($pages as $page) {
             $page->loadDetails();
             $page->url = $page->getFrontendUrl();
-            $page->url = str_replace('.html','',$page->url);
             $page->urlAbsolute = $page->getAbsoluteUrl();
             $subSitemap = new Sitemap($language, $page->id);
             if ($language && $page->language != $language) {

--- a/src/Resources/contao/Sitemap.php
+++ b/src/Resources/contao/Sitemap.php
@@ -31,9 +31,14 @@ class Sitemap implements \IteratorAggregate, \ArrayAccess, \Countable, ContaoJso
         if (!$pages) {
             return;
         }
+        /**
+         * @todo routing error
+         */
+        return;
         foreach ($pages as $page) {
             $page->loadDetails();
             $page->url = $page->getFrontendUrl();
+            $page->url = str_replace('.html','',$page->url);
             $page->urlAbsolute = $page->getAbsoluteUrl();
             $subSitemap = new Sitemap($language, $page->id);
             if ($language && $page->language != $language) {

--- a/src/Resources/contao/Sitemap.php
+++ b/src/Resources/contao/Sitemap.php
@@ -17,7 +17,7 @@ class Sitemap implements \IteratorAggregate, \ArrayAccess, \Countable, ContaoJso
      * constructor.
      *
      * @param string $language If set, ignores other languages
-     * @param int    $pid      Parent ID (for recursive calls)
+     * @param int $pid Parent ID (for recursive calls)
      */
     public function __construct(string $language = null, $pid = null)
     {
@@ -31,13 +31,17 @@ class Sitemap implements \IteratorAggregate, \ArrayAccess, \Countable, ContaoJso
         if (!$pages) {
             return;
         }
-        /**
-         * @todo routing error
-         */
-        return;
+
         foreach ($pages as $page) {
             $page->loadDetails();
-            $page->url = $page->getFrontendUrl();
+
+            // Catch error:
+            // Parameter "parameters" for route "cmf_routing_object" must match "/.+" ("" given) to generate a corresponding URL.
+            try {
+                $page->url = $page->getFrontendUrl();
+            } catch (\Exception $e) {
+                return;
+            }
             $page->urlAbsolute = $page->getAbsoluteUrl();
             $subSitemap = new Sitemap($language, $page->id);
             if ($language && $page->language != $language) {


### PR DESCRIPTION
Stop using $_SESSION['TL_LANGUAGE'] because this is deprecated.

In addition, starting the session "for nothing" makes it impossible to use the shared cache in Contao 4.*.